### PR TITLE
Add cookie-consent styling

### DIFF
--- a/assets/stylesheets/plg-material.css
+++ b/assets/stylesheets/plg-material.css
@@ -31,6 +31,7 @@
   --blue-400:       #60A5FA;  
   --blue-600:       #2563EB;
   --blue-600--25:   #2563eb42;
+  --blue-800:       #1e40af;
   --red-100:        #fee2e2;
   --red-400:        #f87171;
   --red-800:        #991b1b;
@@ -215,6 +216,41 @@
 .md-nav__source {
   background-color: var(--plg-nav-source-bg-color);
   color: white;
+}
+
+
+
+
+/* General consent-bar styling */
+[data-md-component="consent"] > * {
+  left: 0;
+}
+[data-md-component="consent"] > aside {
+  background-color: var(--plg-primary-bg-color);
+}
+[data-md-component="consent"] :is(h4, p) {
+  color: var(--md-primary-bg-color);
+}
+/* Consent-bar buttons wrapper styling */
+[data-md-component="consent"] .md-consent__controls {
+  display: flex;
+  justify-content: center;
+}
+/* Consent-bar buttons styling */
+[data-md-component="consent"] .md-consent__controls > button.md-button.md-button--primary {
+  width: auto !important;
+  padding: 16px 24px;
+  background-color: var(--blue-600);
+  border: none;
+  border-radius: 9999px;
+  color: var(--white);
+  text-align: center;
+  font-weight: 700;
+  transition: background-color 300px;
+}
+[data-md-component="consent"] .md-consent__controls > button.md-button.md-button--primary:focus,
+[data-md-component="consent"] .md-consent__controls > button.md-button.md-button--primary:hover {
+  background-color: var(--blue-800);
 }
 
 
@@ -477,6 +513,14 @@
 
 
 @media screen and (min-width: 60em) {
+  /* Consent-bar buttons wrapper styling */
+  [data-md-component="consent"] .md-consent__controls {
+    justify-content: end;
+  }
+
+
+
+
   /* Toc styling */
   .md-nav--secondary .md-nav__title {
     padding: 0 0.8rem 0.4rem 0.8rem;
@@ -680,6 +724,16 @@
 
   /* Shift content when navigation is fixed */
   body {
+    padding-left: var(--plg-body-nav-offset);
+  }
+}
+
+
+
+
+@media (min-width: 2250px) {
+  /* Align consent-bar with content on ultra-wide resolutions */
+  [data-md-component="consent"] > aside {
     padding-left: var(--plg-body-nav-offset);
   }
 }

--- a/partials/consent.html
+++ b/partials/consent.html
@@ -1,0 +1,88 @@
+{% set cookies = config.extra.consent.cookies | d({}) %}
+{% if config.extra.analytics %}
+  {% if "analytics" not in cookies %}
+    {% set _ = cookies.update({ "analytics": "Google Analytics" }) %}
+  {% endif %}
+{% endif %}
+{% if config.repo_url and "github.com" in config.repo_url %}
+  {% if "github" not in cookies %}
+    {% set _ = cookies.update({ "github": "GitHub" }) %}
+  {% endif %}
+{% endif %}
+
+{% set actions = config.extra.consent.actions %}
+{% if not actions %}
+  {% set actions = ["accept", "manage"] %}
+{% endif %}
+
+{% if "manage" not in actions %}
+  {% set checked = "checked" %}
+{% endif %}
+
+{% if i18n_page_locale %}
+  <h4>{{ config.extra.consent.title[i18n_page_locale] }}</h4>
+  <p>{{ config.extra.consent.description[i18n_page_locale] }}</p>
+{% else %}
+  <h4>{{ config.extra.consent.title }}</h4>
+  <p>{{ config.extra.consent.description }}</p>
+{% endif %}
+
+<input
+  class="md-toggle"
+  type="checkbox"
+  id="__settings"
+  {{ checked }}
+/>
+<div class="md-consent__settings">
+  <ul class="task-list">
+    {% for type in cookies %}
+      {% set checked = "" %}
+      {% if cookies[type] is string %}
+        {% set name = cookies[type] %}
+        {% set checked = "checked" %}
+      {% else %}
+        {% set name = cookies[type].name %}
+        {% if cookies[type].checked %}
+          {% set checked = "checked" %}
+        {% endif %}
+      {% endif %}
+      <li class="task-list-item">
+        <label class="task-list-control">
+          <input type="checkbox" name="{{ type }}" {{ checked }}>
+          <span class="task-list-indicator"></span>
+          {{ name }}
+        </label>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+
+<div class="md-consent__controls">
+  {% for action in actions %}
+
+    {% if action == "accept" %}
+      <button class="md-button md-button--primary">
+        {{- lang.t("consent.accept") -}}
+      </button>
+    {% endif %}
+
+    {% if action == "reject" %}
+      <button type="reset" class="md-button md-button--primary">
+        {{- lang.t("consent.reject") -}}
+      </button>
+    {% endif %}
+
+    {% if action == "manage" %}
+      <label class="md-button" for="__settings">
+        {{- lang.t("consent.manage") -}}
+      </label>
+    {% endif %}
+  {% endfor %}
+</div>
+
+{#
+  mkdocs-material version: 
+    9.5.6
+  changes:
+    - lines 22-28: added if-statement to show localized consent
+#}


### PR DESCRIPTION
### Summary
Added cookie-consent bar styling for light & dark mode, e.g.:
#### light mode
![image](https://github.com/cyfronet-co/plg-material/assets/101113571/dc065458-1a41-418f-8a9c-508e68140f2b)
#### dark mode
![image](https://github.com/cyfronet-co/plg-material/assets/101113571/2def3f12-d10f-4826-bc56-fa30a72320f7)


Also, added handling translations to the cookie consent messages by extending the mkdocs-material partial. The translations may be defined as lang-key in the `config.extra.consent.title/description` scopes, e.g.:
```yml
extra:
  consent:
    title:
      pl: Zgoda na pliki cookie
      en: Cookie consent
    description:
      pl: >-
        W celu świadczenia usług na wysokim poziomie ta strona korzysta z funkcjonalnych i analitycznych plików cookie.
        Kontynuując korzystanie z tej witryny, wyrażasz zgodę na ich używanie.
      en: >-
        This website uses functional and analytical cookies to enhance your browsing experience.
        By continuing to use this website, you consent to the use of cookies.
```
